### PR TITLE
routerLinkActive applied to wrong element

### DIFF
--- a/app/navbar.component.html
+++ b/app/navbar.component.html
@@ -14,8 +14,8 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
-        <li><a routerLink="users" routerLinkActive="active">Users</a></li>
-        <li><a routerLink="posts" routerLinkActive="active">Posts</a></li>
+        <li routerLinkActive="active"><a routerLink="users">Users</a></li>
+        <li routerLinkActive="active"><a routerLink="posts">Posts</a></li>
       </ul>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->


### PR DESCRIPTION
When applied to the anchor tag, the active class only gets applied to the anchor tag, which results in only the text of the link being styled.  When applied to the list item tag, the li's background color is changed as shown in the video for the course.