### PR TITLE
move underscore to globalDependencies

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -2,9 +2,7 @@
   "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160602141332",
     "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
-    "node": "registry:dt/node#6.0.0+20160807145350"
-  },
-  "ambientDependencies": {
-    "underscore": "github:DefinitelyTyped/DefinitelyTyped/underscore/underscore.d.ts#f0990e288ac73d593e982995947567aa2643b828"
+    "node": "registry:dt/node#6.0.0+20160807145350",
+    "underscore": "registry:dt/underscore#1.8.3+20160908111004"
   }
 }


### PR DESCRIPTION
With underscore under ambientDependencies, npm start fails saying it can't find underscore.  Moving underscore to globalDependencies resolves the issue.  I don't know the specifics as to why this is broken, but it was discussed in issue 1.  

https://github.com/mosh-hamedani/angular2-course/issues/1